### PR TITLE
licton-springs-review-nextjs-16-8-bug-typescript-import-error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
+    "baseUrl": ".",
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
resolves #8 
Fixes error when running `npm run build`
![image](https://github.com/user-attachments/assets/33c7867c-eabd-462e-9e6c-5c1647a704a7)
### Description:
This pull request addresses the following TypeScript error:
`Type error: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?`

### Root Cause:
The error occurs because non-relative import paths (e.g., import Button from 'components/Button') are used without a baseUrl set in tsconfig.json. TypeScript requires a baseUrl to resolve such imports.

### Solution Implemented:

Added "baseUrl": "." to compilerOptions in tsconfig.json to allow non-relative imports to resolve from the src directory.
Updated existing imports to use non-relative paths where appropriate for consistency and readability.
Changes Made:

Updated tsconfig.json:
```
{
  "compilerOptions": {
    "baseUrl": ".",
    ...
  }
}
```

### To test:
1. Open project and run `npm install`
2. run `npm run build`
3. Observe successful compilation
![image](https://github.com/user-attachments/assets/fc4b2372-dc1a-46b5-82a0-f79074d74b01)

Here is an article i referenced to fix this:
https://peterkellner.net/2023/09/15/Resolving-TypeScript-Errors-in-Nextjs/