### PR TITLE
licton-springs-review-nextjs_19_Issue67-add-logo-slogan

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -34,6 +34,7 @@ body {
 /* Header */
 .header {
   display: flex;
+  flex-direction: column; 
   justify-content: center;
   align-items: center;
   padding: 20px;
@@ -92,7 +93,6 @@ body {
   padding: 16px;
  }
 
-
  .navbar ul {
   display: flex;
   justify-content: center;
@@ -102,7 +102,6 @@ body {
   color: #333;
  }
 
-
  /* Header */
  .header {
   display: flex;
@@ -110,7 +109,6 @@ body {
   align-items: center;
   padding: 20px;
  }
-
 
  .header-logo {
   max-width: 900px;
@@ -122,7 +120,6 @@ body {
   padding: 16px;
  }
 
-
  .footer ul {
   display: flex;
   justify-content: center;
@@ -131,3 +128,11 @@ body {
   font-weight: 600;
   color: #333;
  }
+
+/* Slogan */
+.slogan {
+  margin-top: 10px; 
+  font-size: 10pt; 
+  font-style: italic;
+   color: #4a4a4a; 
+}

--- a/src/component/Header.tsx
+++ b/src/component/Header.tsx
@@ -9,6 +9,9 @@ export default function Header() {
                 width="595" height="90"
                 className="header-logo"
             />
+            <p className="slogan">
+                Visual and literary art from the students, staff, faculty, and alumni of North Seattle College
+            </p>
         </header>
     );
 }


### PR DESCRIPTION
**Resolves:** Issue #67

**Description:** This pull request adds the LSR "Slogan" below the title.
- [x] The slogan is added below the title.
- [x] The slogan reads: "Visual and literary art from the students, staff, faculty, and alumni of North Seattle College."
- [x] The layout remains clean and consistent.

**How to Test:**
1. Pull the latest changes.
2. Run npm run dev.
3. Go to: http://localhost:3000/
4. Verify that the slogan appears below the title.

**Expected Result:**
* The slogan should be displayed below the title.
* The page layout should remain consistent.

**Screenshot of Result:**
<img width="1195" alt="Slogan" src="https://github.com/user-attachments/assets/0c40ec16-93a4-4841-86ee-af00311e5085" />
