### PR TITLE
licton-springs-review-nextjs_19_Issue70-removal-of-Link-page 

### DIFF
--- a/src/component/Footer.tsx
+++ b/src/component/Footer.tsx
@@ -21,9 +21,8 @@ export default function Footer() {
         <li>
           <Link href="help">Help</Link>
         </li>
-        <li>
-          <Link href="link">Link</Link>
-        </li>
+          
+        
         <li>
           <Link href="https://www.getrave.com/login/seattlecolleges">
           <Image src="/rave.png" alt="image of NSC Logo" width="170" height="40" />
@@ -45,9 +44,6 @@ export default function Footer() {
           </li>
           <li>
             <Link href="help">Help</Link>
-          </li>
-          <li>
-            <Link href="link">Link</Link>
           </li>
         </ul>
       </nav> */}


### PR DESCRIPTION
Resolves: https://github.com/SeattleColleges/licton-springs-review-nextjs/issues/70

Description: 
This pull request removes the "Link" button/page from the header menu to improve navigation.

 The "Link" button is removed from the footer menu.
 The solution is tested to ensure proper functionality.
How to Test:
Pull the latest changes.
Run npm run dev
Go to: http://localhost:3000/
Verify that the "Link" button is no longer present in the footer.


Expected Result: 
The "Link" button should no longer appear in the footer.


Screenshot of Result:
<img width="1461" alt="Screenshot 2025-02-28 at 8 23 05 PM" src="https://github.com/user-attachments/assets/1302a629-31bc-414f-96c5-5777f8dd9600" />
