### PR TITLE
licton-springs-review-nextjs_19_Issue68-bugfix/fix-arts-page-404

### DIFF
--- a/src/component/Footer.tsx
+++ b/src/component/Footer.tsx
@@ -10,7 +10,7 @@ export default function Footer() {
           <img src="/north-seattle-tree-frogs.png" alt="image of NSC Logo" width="160" height="80" />
         </li>
         <li>
-          <Link href="/archive">Archive</Link>
+          <Link href="/archives">Archives</Link>
         </li>
         <li>
           <Link href="job">Job</Link>

--- a/src/component/Navbar.tsx
+++ b/src/component/Navbar.tsx
@@ -10,7 +10,7 @@ export default function Navbar() {
           <Link href="/audio">Audio</Link>
         </li>
         <li>
-          <Link href="/arts">Arts</Link>
+          <Link href="/art">Art</Link>
         </li>
         <li>
           <Link href="/fiction">Fiction</Link>


### PR DESCRIPTION
Description
This is a pull request to resolve issue https://github.com/SeattleColleges/licton-springs-review-nextjs/issues/68

The "Art"  and "Archieves" shows Hello  World!

The solution is tested to ensure proper functionality.
How to Test:
Pull the latest changes.
Run npm run dev
Go to: http://localhost:3000/

Verify that the "Art" and "Archieves" doesn't show 404 error.


![Screenshot 2025-02-28 at 9 27 46 PM](https://github.com/user-attachments/assets/7941d856-701b-4c74-96bd-bd7afebddec5)
![Screenshot 2025-02-28 at 9 27 37 PM](https://github.com/user-attachments/assets/0bfe6ec0-8e4b-4af1-a2a7-af9ef1a93b39)

