### PR TITLE
licton-springs-review-nextjs_19_69_fetch-page-content-from-wordpress

### DIFF
--- a/src/app/art/page.tsx
+++ b/src/app/art/page.tsx
@@ -1,8 +1,11 @@
+import Link from "next/link";
+
 export default function ArtPage() {
     return (
       <main>
         <h1>Art</h1>
         <p>Hello World!</p>
+        <Link href="/art/post?id=2806">Post Detail</Link>
       </main>
     );
   }

--- a/src/app/art/post/page.tsx
+++ b/src/app/art/post/page.tsx
@@ -1,0 +1,4 @@
+import Detail from "@/component/Detail";
+export default function ArtPost() {
+    return <Detail/>
+}

--- a/src/component/Detail.tsx
+++ b/src/component/Detail.tsx
@@ -1,0 +1,250 @@
+//lets us use useEffect, useState, use*...
+"use client";
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+//he library encodes/decodes HTML entities eg &#8220; -> "
+import * as he from "he";
+
+//structure of data returned from API
+interface PostAPI {
+    "id": number,
+    "date": string,
+    "date_gmt": string,
+    "guid": {"rendered": string},
+    "modified": string,
+    "modified_gmt": string,
+    "slug": string,
+    "status": string,
+    "type": string,
+    "link": string,
+    "title": {"rendered": string},
+    "content": {
+        "rendered": string,
+        "protected": boolean
+    },
+    "excerpt": {
+        "rendered": string,
+        "protected": boolean
+    },
+    "author": number,
+    "featured_media": number,
+    "comment_status": string,
+    "ping_status": string,
+    "sticky": boolean,
+    "template": string,
+    "format": string,
+    "meta": {
+        "iawp_total_views": number,
+        "footnotes": string
+    },
+    "categories": number[],
+    "tags": number[],
+    "class_list": string[],
+    "_links": {
+        "self": {
+            "href": string,
+            "targetHints": {"allow": string[]}
+        }[],
+        "collection": {"href": string}[],
+        "about": {"href": string}[],
+        "author": {
+            "embeddable": boolean,
+            "href": string
+        }[],
+        "replies": {
+            "embeddable": boolean,
+            "href": string
+        }[],
+        "version-history": {
+            "count": number,
+            "href": string
+        }[],
+        "predecessor-version": {
+            "id": number,
+            "href": string
+        }[],
+        "wp:featuredmedia": {
+            "embeddable": boolean,
+            "href": string
+        }[],
+        "wp:attachment": {
+            "href": string
+        }[],
+        "wp:term": {
+            "taxonomy": string,
+            "embeddable": boolean,
+            "href": string
+        }[],
+        "curies": {
+            "name": string,
+            "href": string,
+            "templated": boolean
+        }[]
+    }
+}
+
+//defines valid structure for post data to be displayed
+interface PostData {
+    "title": string,
+    "category": string,
+    // "authorType": string,
+    "date": string,
+    "content": string
+}
+
+export default function Detail() {
+    //so we can get query params from url, eg url?id=1
+    const searchParams = useSearchParams();
+
+    //data should be either the above structure or null, with an initial value of null
+    const [data, setData] = useState<PostData | null>(null);
+    
+    //fetches data for the post and sets state
+    useEffect(() => {
+        //retrieves the post data JSON from the API or null if no/invalid ID
+        function fetchData(): PostAPI | null {
+            //get id from query params
+            const id = searchParams.get("id");
+            
+            let result = null;
+            if (id != null && id !== "") {
+                //fetch post with that id
+                fetch("https://lictonspringsreview.com/wp-json/wp/v2/posts/" + id)
+                .then(response => {
+                    if (response.ok) {
+                        return response.json();
+                    } else {
+                        return null;
+                    }
+                }).then(json => {
+                    result = json;
+                })
+            }
+            return result;
+        }
+
+        async function cleanData(): Promise<void> {
+            const roughData = await fetchData();
+            if (roughData === null) return;
+
+            const cleanedTitle = cleanTitle(roughData.title.rendered);
+
+            const cleanedData = {
+                title: cleanedTitle,
+                category: await cleanCategories(roughData.categories),
+                date: cleanDate(roughData.date),
+                //checking the original content title is faster than searching long content string for video
+                content: cleanImage(roughData.content.rendered, roughData.title.rendered, cleanedTitle)
+            };
+            setData(cleanedData);
+        }
+
+        function cleanTitle(orig: string) {
+            //remove CATEGORY:<br>
+            let cleaned = orig.substring(orig.indexOf("<br/>") + 5).trim();
+            //replace html entities eg &#8220; and &#8221; (quotes) with appropriate chars
+            cleaned = he.decode(cleaned);
+            return cleaned;
+        }
+
+        //gets string labels for categories (type only, not author / other cats)
+        async function cleanCategories(cats: number[]) {
+            //Just collect all the types (there should just be one but I don't know that it's guaranteed...)
+            const validCategories = ["Nonfiction", "Fiction", "Poetry", "Visual Art"];
+            
+            //We no longer care about author type
+            // const authors: {[key: string]: string} = {"19": "alumni", "18": "staff", "17": "faculty", "16": "student", "1": "uncategorized"};
+            
+            let type = "";
+            for (let i = 0; i < cats.length; i++) {
+                const cat = cats[i];
+                console.log("Category #" + i)
+                const res = await fetch("https://lictonspringsreview.com/wp-json/wp/v2/categories/" + cat);
+                if (res.ok) {
+                    const name = (await res.json()).name;
+                    if (validCategories.includes(name)) {
+                        if (type == "") type = name;
+                        else type += ", " + name;
+                    }
+                }
+            }
+            if (type === "") {
+                type = "Uncategorized"
+            }
+            return type;
+        }
+
+        function cleanDate(date: string) {
+            return date.substring(0, 10);
+        }
+
+        function cleanImage(content: string, origTitle: string, cleanTitle: string) {
+            //for art posts, either it's an image/figure or that one weird video post (not categorized as video btw)
+            //all nonvideo art posts contain img, some contain figure and img
+            //if img, src="" alt="" width="" height="" srcset="" are all next to each other in that order
+            
+            if (origTitle.substring(0, 5) === "VIDEO") {
+                return "video src=...";
+            } else { //it's an image
+                //each field is in this literal format: a=\"x\" b=\"y\" ...
+                //to extract, we would need indexOf("\"") + 1, indexOf(nextField) - 2 (exclusive)
+                //then update the starting index to be indexOf(nextField) and continue
+                //the final field, height, would want to go to the end - 2 (exclusive)
+                
+                //all the fields we care about, in this order: src, alt, width, height
+                const extraction = content.substring(content.indexOf("src="), content.indexOf("srcset"));
+
+                //extract src
+                let startIndex = extraction.indexOf("\"") + 1;
+                let endIndex = extraction.indexOf("alt") - 2;
+                const src = extraction.substring(startIndex, endIndex);
+
+                //extract alt OR use title
+                let currStr = extraction.substring(endIndex);
+                startIndex = currStr.indexOf("\"") + 1;
+                endIndex = currStr.indexOf("wid") - 2;
+                let alt = currStr.substring(startIndex, endIndex);
+                if (alt.trim() === "") {
+                    alt = "Visual Art: " + cleanTitle;
+                }
+
+                //extract width
+                currStr = currStr.substring(endIndex);
+                startIndex = currStr.indexOf("\"") + 1;
+                endIndex = currStr.indexOf("hei") - 2;
+                const width = currStr.substring(startIndex, endIndex);
+
+                //extract height
+                currStr = currStr.substring(endIndex);
+                startIndex = currStr.indexOf("\"") + 1;
+                const height = currStr.substring(startIndex, currStr.length - 3);
+                
+                //done
+                return "<Image src='" + src + "' alt='" + alt + "' width='" + width + "' height='" + height + "'>";
+            }
+        }
+
+        cleanData().then(() => console.log("DONE"));
+    }, [searchParams]); //runs once
+
+    //if there is no id, or id is not a positive whole number, or fetch() returns data.status == 404
+    //extract: titlebyauthor, category (type and author type), postdate, content
+    if (data === null) {
+        return (<>
+            <h1>Post not found</h1>
+            <Link href="/">Back to Home</Link>
+        </>);
+    } else {
+        return ( 
+            <article>
+                <h1>{data.title}</h1>
+
+                <p>Published in {data.category}</p>
+                <p>Posted on {data.date}</p>
+                <p>{data.content}</p> {/** or an image */}
+                <a href="/art">More Art</a>
+            </article>
+        );
+    }
+}

--- a/src/fetch-wp-content.tsx
+++ b/src/fetch-wp-content.tsx
@@ -1,0 +1,139 @@
+// const categories = [
+//     {"id": 19,  "count": 7,     "slug": "alumni"},
+//     {"id": 18,  "count": 1,     "slug": "staff"},
+//     {"id": 17,  "count": 1,     "slug": "faculty"},
+//     {"id": 16,  "count": 29,    "slug": "student"},
+//     {"id": 8,   "count": 1,     "slug": "nonfiction"},
+//     {"id": 7,   "count": 5,     "slug": "fiction"},
+//     {"id": 6,   "count": 17,    "slug": "poetry"},
+//     {"id": 5,   "count": 15,    "slug": "visualart"},
+//     {"id": 1,   "count": 2,     "slug": "uncategorized"}
+// ];
+
+// "id": 2806,
+//         "date": "2024-09-20T18:02:29",
+//         "title": {
+//             "rendered": "VISUAL ART: <br/> &#8220;Early Bloom&#8221; by Calan Simpson-Felicia"
+//         },
+//         "content": {
+//             "rendered":
+//             <p>
+//                 <img loading=\"lazy\" decoding=\"async\" 
+//                 class=\"aligncenter size-full wp-image-2807\" 
+//                 src=\"https://lictonspringsreview.com/wp-content/uploads/2024/06/Early-Bloom-main.jpg\" 
+//                 alt=\"\" width=\"1900\" height=\"1267\" 
+//                 srcset=\"https://lictonspringsreview.com/wp-content/uploads/2024/06/Early-Bloom-main.jpg 1900w, https://lictonspringsreview.com/wp-content/uploads/2024/06/Early-Bloom-main-300x200.jpg 300w, https://lictonspringsreview.com/wp-content/uploads/2024/06/Early-Bloom-main-1024x683.jpg 1024w, https://lictonspringsreview.com/wp-content/uploads/2024/06/Early-Bloom-main-768x512.jpg 768w, https://lictonspringsreview.com/wp-content/uploads/2024/06/Early-Bloom-main-1536x1024.jpg 1536w\" 
+//                 sizes=\"auto, (max-width: 1900px) 100vw, 1900px\" /></p>\n",
+//             "protected": false
+//         },
+//         "excerpt": {
+//             "rendered": "",
+//             "protected": false
+//         },
+//         "categories": [
+//             19,
+//             5
+//         ],
+
+
+//     "id": 2682,
+//     "date":     "2024-03-08T09:00:09",
+//     "title": {
+//         "rendered": "&#8220;Moi&#8221; by Liliana Gutierrez-Pino"
+//     },
+//     "content": {
+//         "rendered": 
+//             "<figure
+//             id=\"attachment_2684\"
+//             aria-describedby=\"caption-attachment-2684\"
+//             style=\"width: 1707px\"
+//             class=\"wp-caption aligncenter\"
+//             >
+//                 <a
+//                 href=\"https://lictonspringsreview.com/wp-content/uploads/2024/03/A468full-scaled.jpg\"
+//                 target=\"_blank\"
+//                 rel=\"noopener\"
+//                 >
+//                     <img
+//                         loading=\"lazy\"
+//                         decoding=\"async\"
+//                         class=\"wp-image-2684 size-full\"
+//                         src=\"https://lictonspringsreview.com/wp-content/uploads/2024/03/A468full-scaled.jpg\"
+//                         alt=\"\"
+//                         width=\"1707\"
+//                         height=\"2560\"
+//                         srcset=\"
+//                             https://lictonspringsreview.com/wp-content/uploads/2024/03/A468full-scaled.jpg 1707w,
+//                             https://lictonspringsreview.com/wp-content/uploads/2024/03/A468full-200x300.jpg 200w,
+//                             https://lictonspringsreview.com/wp-content/uploads/2024/03/A468full-683x1024.jpg 683w,
+//                             https://lictonspringsreview.com/wp-content/uploads/2024/03/A468full-768x1152.jpg 768w,
+//                             https://lictonspringsreview.com/wp-content/uploads/2024/03/A468full-1024x1536.jpg 1024w,
+//                             https://lictonspringsreview.com/wp-content/uploads/2024/03/A468full-1365x2048.jpg 1365w\"
+//                             sizes=\"auto, (max-width: 1707px) 100vw, 1707px\"
+//                     />
+//                 </a>
+//                 <figcaption
+//                 id=\"caption-attachment-2684\"
+//                 class=\"wp-caption-text\"
+//                 >&#8220;Moi&#8221; by Liliana Gutierrez-Pino, Student<br />Digital Collage with Original Photography
+//                 </figcaption>
+//             </figure>
+//             \n",
+//     },
+//     "excerpt": {
+//         "rendered": "",
+//     },
+//     "categories": [
+//         16,
+//         5
+//     ]
+
+// //ok so basically
+//     <article>
+//         <a href="post?id=" + id>
+//             <h2>"Title" by Author</h2>
+//         </a>
+//         <p>Posted on ...</p>
+//         <a href="post?id=" + id>
+//             <img src="" alt="" width="" height="" srcset=""/>
+//         </a>
+//     </article>
+
+//     which links to
+
+//     <article>
+//         <h1>"Title" by Author</h1>
+//         <p>Category1 Category2</p>
+//         <p>Posted on ...</p>
+//         <img src="" alt="" width="" height="" srcset=""/>
+//     </article>
+//     <a href="?">Back</a>
+
+//     For text content, img would be replaced by <p>excerpt...</p> and page img would be replaced by <p>content</p>
+
+// async function fetchPosts(categoryId: number, pageNumber: number = 1) {
+//     const res = await fetch("http://lictonspringsreview.com/wp-json/wp/v2/posts/categories=" + categoryId + "&" + "page=" + pageNumber)
+//     const data = await res.json();
+//     return data;
+// }
+
+// async function cleanPosts(posts: ) {
+
+// }
+
+// async function displayPosts() {
+//     let posts = await fetchPosts(5, 1);
+//     if (posts.length === 0) {
+//         return <p>There are currently no posts for this category</p>;
+//     } else {
+//         cleanPosts(posts);
+//     }
+// }
+
+
+
+// ///ok
+// //so, each page has a list of posts
+// //when you click post, it goes to detail page, back buttons goes back to page with list of posts
+// //can I do with one page/component? maybe but probs shouldn't
+// //but I can do a single component that just gets passed its category and id and call it from each page

--- a/src/fetch-wp-content.tsx
+++ b/src/fetch-wp-content.tsx
@@ -1,139 +1,19 @@
-// const categories = [
-//     {"id": 19,  "count": 7,     "slug": "alumni"},
-//     {"id": 18,  "count": 1,     "slug": "staff"},
-//     {"id": 17,  "count": 1,     "slug": "faculty"},
-//     {"id": 16,  "count": 29,    "slug": "student"},
-//     {"id": 8,   "count": 1,     "slug": "nonfiction"},
-//     {"id": 7,   "count": 5,     "slug": "fiction"},
-//     {"id": 6,   "count": 17,    "slug": "poetry"},
-//     {"id": 5,   "count": 15,    "slug": "visualart"},
-//     {"id": 1,   "count": 2,     "slug": "uncategorized"}
-// ];
-
-// "id": 2806,
-//         "date": "2024-09-20T18:02:29",
-//         "title": {
-//             "rendered": "VISUAL ART: <br/> &#8220;Early Bloom&#8221; by Calan Simpson-Felicia"
-//         },
-//         "content": {
-//             "rendered":
-//             <p>
-//                 <img loading=\"lazy\" decoding=\"async\" 
-//                 class=\"aligncenter size-full wp-image-2807\" 
-//                 src=\"https://lictonspringsreview.com/wp-content/uploads/2024/06/Early-Bloom-main.jpg\" 
-//                 alt=\"\" width=\"1900\" height=\"1267\" 
-//                 srcset=\"https://lictonspringsreview.com/wp-content/uploads/2024/06/Early-Bloom-main.jpg 1900w, https://lictonspringsreview.com/wp-content/uploads/2024/06/Early-Bloom-main-300x200.jpg 300w, https://lictonspringsreview.com/wp-content/uploads/2024/06/Early-Bloom-main-1024x683.jpg 1024w, https://lictonspringsreview.com/wp-content/uploads/2024/06/Early-Bloom-main-768x512.jpg 768w, https://lictonspringsreview.com/wp-content/uploads/2024/06/Early-Bloom-main-1536x1024.jpg 1536w\" 
-//                 sizes=\"auto, (max-width: 1900px) 100vw, 1900px\" /></p>\n",
-//             "protected": false
-//         },
-//         "excerpt": {
-//             "rendered": "",
-//             "protected": false
-//         },
-//         "categories": [
-//             19,
-//             5
-//         ],
-
-
-//     "id": 2682,
-//     "date":     "2024-03-08T09:00:09",
-//     "title": {
-//         "rendered": "&#8220;Moi&#8221; by Liliana Gutierrez-Pino"
-//     },
-//     "content": {
-//         "rendered": 
-//             "<figure
-//             id=\"attachment_2684\"
-//             aria-describedby=\"caption-attachment-2684\"
-//             style=\"width: 1707px\"
-//             class=\"wp-caption aligncenter\"
-//             >
-//                 <a
-//                 href=\"https://lictonspringsreview.com/wp-content/uploads/2024/03/A468full-scaled.jpg\"
-//                 target=\"_blank\"
-//                 rel=\"noopener\"
-//                 >
-//                     <img
-//                         loading=\"lazy\"
-//                         decoding=\"async\"
-//                         class=\"wp-image-2684 size-full\"
-//                         src=\"https://lictonspringsreview.com/wp-content/uploads/2024/03/A468full-scaled.jpg\"
-//                         alt=\"\"
-//                         width=\"1707\"
-//                         height=\"2560\"
-//                         srcset=\"
-//                             https://lictonspringsreview.com/wp-content/uploads/2024/03/A468full-scaled.jpg 1707w,
-//                             https://lictonspringsreview.com/wp-content/uploads/2024/03/A468full-200x300.jpg 200w,
-//                             https://lictonspringsreview.com/wp-content/uploads/2024/03/A468full-683x1024.jpg 683w,
-//                             https://lictonspringsreview.com/wp-content/uploads/2024/03/A468full-768x1152.jpg 768w,
-//                             https://lictonspringsreview.com/wp-content/uploads/2024/03/A468full-1024x1536.jpg 1024w,
-//                             https://lictonspringsreview.com/wp-content/uploads/2024/03/A468full-1365x2048.jpg 1365w\"
-//                             sizes=\"auto, (max-width: 1707px) 100vw, 1707px\"
-//                     />
-//                 </a>
-//                 <figcaption
-//                 id=\"caption-attachment-2684\"
-//                 class=\"wp-caption-text\"
-//                 >&#8220;Moi&#8221; by Liliana Gutierrez-Pino, Student<br />Digital Collage with Original Photography
-//                 </figcaption>
-//             </figure>
-//             \n",
-//     },
-//     "excerpt": {
-//         "rendered": "",
-//     },
-//     "categories": [
-//         16,
-//         5
-//     ]
-
-// //ok so basically
+//     //ok so basically the plan for lists of posts is, for each post:
 //     <article>
-//         <a href="post?id=" + id>
-//             <h2>"Title" by Author</h2>
-//         </a>
-//         <p>Posted on ...</p>
-//         <a href="post?id=" + id>
-//             <img src="" alt="" width="" height="" srcset=""/>
-//         </a>
+//         <Link href="/post?id={id}">
+//             <h2>{cleanedTitle}</h2>
+//         </Link>
+//         <p>Posted on {cleanedDate}</p>
+//         // For text content, Image would be replaced by <p>excerpt...</p>
+//         <Link href="/post?id={id}">
+//             <Image src="{src}" alt="{alt}" width="{width}" height="{height}"/>
+//         </Link>
 //     </article>
 
-//     which links to
+//     which links to /post?id={id} which fetches Detail component and displays single post
 
-//     <article>
-//         <h1>"Title" by Author</h1>
-//         <p>Category1 Category2</p>
-//         <p>Posted on ...</p>
-//         <img src="" alt="" width="" height="" srcset=""/>
-//     </article>
-//     <a href="?">Back</a>
-
-//     For text content, img would be replaced by <p>excerpt...</p> and page img would be replaced by <p>content</p>
-
-// async function fetchPosts(categoryId: number, pageNumber: number = 1) {
-//     const res = await fetch("http://lictonspringsreview.com/wp-json/wp/v2/posts/categories=" + categoryId + "&" + "page=" + pageNumber)
+// async function fetchPosts(categoryId: number) {
+//     const res = await fetch("http://lictonspringsreview.com/wp-json/wp/v2/posts/categories=" + categoryId)
 //     const data = await res.json();
 //     return data;
 // }
-
-// async function cleanPosts(posts: ) {
-
-// }
-
-// async function displayPosts() {
-//     let posts = await fetchPosts(5, 1);
-//     if (posts.length === 0) {
-//         return <p>There are currently no posts for this category</p>;
-//     } else {
-//         cleanPosts(posts);
-//     }
-// }
-
-
-
-// ///ok
-// //so, each page has a list of posts
-// //when you click post, it goes to detail page, back buttons goes back to page with list of posts
-// //can I do with one page/component? maybe but probs shouldn't
-// //but I can do a single component that just gets passed its category and id and call it from each page


### PR DESCRIPTION
This is a DRAFT PR for review, feedback, and to split up remaining tasks fetching posts

To do:
[ ] Extract data fetching, cleaning, and extraction to fetch-wp-content.tsx in order to export and reuse functions in multiple pages, like art/post, poetry/post, any other pages
[ ] Modify image handler to handle multiple images in one post's content
[ ] Implement video post handler
[ ] Implement text post handler
[ ] Implement fetching list of posts of a certain category and using existing functions to clean and extract list of data for display in multiple pages, like /art, /poetry, /nonfiction, any other pages

## Summary & Changes 📃
- **Resolves:** `#69`

- **Summary:** (Briefly describe what this PR does)
  - Adds functionality to fetch a single post from the Wordpress API, clean the JSON and extract needed data, and display it
  - During the fetch and cleaning process, "Loading" is displayed.
  - In the case of a missing or invalid ID, "Post not found" is displayed.
  - Interfaces (typing) have been added to define expected structure of API JSON response, Image content, Post content for TypeScript requirements
  - SearchParams is used to access query params, eg art/post?id=5 would get(id) === 5
  - State tracks whether content is currently **loading**, and post content is saved in **data**
  - UseEffect runs once on render, and uses async functions with await to fetch JSON from API, clean and extract content, and save the result to **data** (state) which then triggers rendering
  - Cleaning process handles content: image post differently from text post and video post (because they are different html tags in the content). Straightforward cleaning is done with date, category, title
  - There is no video category, videos should be listed with others for their category, for example, there is a post in Visual Art that has the title VIDEO: x and a <video> tag in the content rather than an <img>
  - Finally, the Detail component displays different content for if still loading, if invalid post id, or displays the post content, which changes depending on the kind of post


_**To test:**_
Pull licton-springs-review-nextjs_19_69_fetch-page-content-from-wordpress branch content into a local testing branch
Run npm run dev
Open localhost:3000/art
Verify a link "Post Detail" is there and click it to go to localhost:3000/art/post?id=2806
Notice a brief initial "Loading" message during the fetch process
The page should soon load the content for post:
“Early Bloom” by Calan Simpson-Felicia
Published in Art
Posted on 2024/9/20
(Image)
A link back to /art

![image](https://github.com/user-attachments/assets/f0233004-1484-4052-be52-5c5899a48903)

  - 🔨 What does this issue fix?
  - 👀 What is the expected behavior?
  - 🗨️ Any relevant technical details?

- **Changes:**
  - ✅ List key changes made
  - 🛠️ Mention breaking changes (if any)
  - 🔗 Link relevant discussions/issues
  - 📝 Additional info to assist developers & reviewers


## Screenshots / Visual Aids 🔎
<sub><i>📌 **Required for:** UI changes, layout updates, or bug fixes.</i></sub>

<details>
  <summary> Expand ⬇️ </summary>
  <!-- add GIFs/Screenshots/Videos/Diagrams here -->
</details>


## How to Test 🧪
1. **Steps to Reproduce:**
   - Step 1: ...
   - Step 2: ...
2. **Expected Behavior:** (Describe what should happen)
3. **Actual Behavior (if bug):** (Describe what happens instead)


## Checklist ✅

- [ ] I have **tested** this PR **locally** and it works as expected.
- [ ] This PR **resolves an issue** (`Resolves #issue-number`).
- [ ] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [ ] **Squash commits** and enable **auto-merge** if approved.

