### PR TITLE
licton-springs-review-nextjs_20_69_load-audio-page-content

### DIFF
--- a/src/app/audio/page.tsx
+++ b/src/app/audio/page.tsx
@@ -1,8 +1,17 @@
+import { PostsByCategory } from "@/component/PostsByCategory";
+import { getCategoryId } from "@/fetch-category-posts";
+
 export default function Audio() {
-    return (
-        <>
-            <h1>Audio</h1>
-            <p>Hello world!</p>
-        </>
-    );
+    return getCategoryId("Audio")
+    .then((id) => {
+        const content = id === -1 ? 
+                        <p>There are currently no posts for Audio. Submit your work today!</p> :
+                        <PostsByCategory category="Audio"/>
+        return (
+            <main className="audio-container">
+                <h1>Audio</h1>
+                {content}
+            </main>
+        );
+    })
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -616,3 +616,15 @@ textarea {
   border-radius: 8px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
+
+/* Audio */
+.audio-container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px;
+}
+.audio-container h1 {
+  text-align: center;
+  font-size: 2rem;
+  margin-bottom: 20px; 
+}


### PR DESCRIPTION
## Summary & Changes 📃
- **Resolves:** `#69`
- **Summary:** (Briefly describe what this PR does)
  - 🔨 What does this issue fix?
  - There is no Audio category or content on Wordpress currently, so the <PostsByCategory category="Audio"> component displays "Category not found".
  - 👀 What is the expected behavior?
  - To resolve this, I added a check to see if getCategoryId("Audio") returns -1. If so, it displays the message "There are currently no posts for Audio. Submit your work today!"
  - 🗨️ Any relevant technical details?
  - If in the future, the Audio category is added to WP, this page will automatically load the relevant posts.

- **Changes:**
  - ✅ List key changes made
  - Updated audio/page.tsx to display appropriate content rather than hello world
  - Added styles to globals.css
  - Until the Audio category is added to WP, will display a message that there are no Audio posts
  - If the Audio category is added to WP, will display all posts for that category

## Screenshots / Visual Aids 🔎
![image](https://github.com/user-attachments/assets/971b5b70-03eb-4787-8d29-dbdd27273b6f)

## How to Test 🧪
1. **Steps to Reproduce:**
   - Step 1: pull branch into a local testing branch using ```git pull origin licton-springs-review-nextjs-20-69-load-audio-page-content```
   - Step 2: Run ```npm run dev``` and navigate to localhost:3000 in your browser.
   - Step 3: Click Audio link to navigate to localhost:3000/audio
2. **Expected Behavior:** (Describe what should happen)
  - It should display the message "There are currently no posts for Audio. Submit your work today!"

## Checklist ✅
- [x] I have **tested** this PR **locally** and it works as expected.
- [x] This PR **resolves an issue** (`Resolves #69`).
- [x] **Reviewers, assignees(self), tags, and labels** are correctly assigned.
- [x] **Squash commits** and enable **auto-merge** if approved.