### PR TITLE
licton-springs-review-nextjs-103-font-change

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,6 +8,7 @@
 body {
   width: 100%;
   overflow-x: hidden;
+  font-family: 'Castoro', serif;
 }
 
 html, body {
@@ -26,6 +27,7 @@ html, body {
 }
 
 .header-logo {
+  width: 100%;
   max-width: 900px;
   height: auto;
 }
@@ -104,13 +106,6 @@ html, body {
   color: gray; 
 }
 
-/* Slogan */
-.slogan {
-  margin-top: 10px; 
-  font-size: 10pt; 
-  font-style: italic;
-   color: #4a4a4a; 
-}
 
 /* Date */
 .date-container {
@@ -203,7 +198,6 @@ button img {
   max-width: 900px;
   margin: auto;
   padding: 20px;
-  font-family: Arial, sans-serif;
 }
 
 .submit-title {
@@ -376,9 +370,8 @@ textarea {
 /* Slogan */
 .slogan {
   margin-top: 10px; 
-  font-size: 10pt; 
-  font-style: italic;
-   color: #4a4a4a; 
+  font-size: 10pt;
+  color: #4a4a4a; 
 }
 
 /* Date */
@@ -472,7 +465,6 @@ textarea {
 }
 
 /* Fiction */
-
 .fiction-container {
   max-width: 800px;
   margin: 0 auto;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,6 +28,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        <link
+          href="https://fonts.googleapis.com/css2?family=Castoro&display=swap"
+          rel="stylesheet"
+        />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/src/component/styles/Detail.module.css
+++ b/src/component/styles/Detail.module.css
@@ -4,6 +4,10 @@
   padding: 20px;
   background-color: #fff;
   line-height: 1.6;
+  font-family: 'Castoro', serif !important;
+}
+.detailContainer * {
+  font-family: 'Castoro', serif !important;
 }
 
 .fictionTitle {
@@ -30,6 +34,11 @@
   line-height: 1.6; 
 }
 
+.contentContainer, 
+.contentContainer * {
+  font-family: 'Castoro', serif;
+}
+
 /* Images inside content */
 .contentContainer figure {
   margin: 20px 0;
@@ -48,6 +57,7 @@
 .contentContainer p {
   margin-bottom: 20px;
   font-size: 1.1rem;
+  font-family: 'Castoro', serif !important;
 }
 
 .contentContainer h2 {


### PR DESCRIPTION
**Resolves:** Issue #103

**Description:**
- [x] Changed the global font and slogan font to Castoro.
- [x] Applied Castoro font to all body text and slogan.
- [x] Added a fallback serif font for compatibility.
- [x] Ensured font loads
- [x] Verified layout and spacing work correctly after the font update.

**How to Test:**
1. Pull the latest changes
2.  Run npm run dev
3. Visit any page with body text and the slogan
4. Verify the font is Castoro everywhere (including the slogan)
5. Confirm there is a fallback Serif font if Castoro fails to load
6. Check that layout and spacing appear consistent and no elements break

**Expected Result:**
- [ ] Castoro font is visible on all body text and the slogan
- [ ] Fallback font works
- [ ] Layout and spacing remain clean and consistent
- [ ] Font loads quickly without blocking page rendering

**Screenshots of Results:**

### Home Page
![localhost_3000_ (3)](https://github.com/user-attachments/assets/f5fa6a72-7978-40ad-9a0d-87665fbb611d)

### Submit Page
![localhost_3000_submit](https://github.com/user-attachments/assets/3dcf0dc8-ab17-4383-8796-10d787d240bb)

### Contents
![localhost_3000_fiction](https://github.com/user-attachments/assets/79dfa11d-4dcb-4d55-9d8b-6cb4176b88d9)

![localhost_3000_poetry_post_id=2804 (3)](https://github.com/user-attachments/assets/b6dfa616-f558-4d9d-99f2-093867f61693)




