### PR TITLE
licton-springs-review-nextjs_sprint-23_109_change-banner-color

### DIFF
--- a/src/app/archives/page.tsx
+++ b/src/app/archives/page.tsx
@@ -1,9 +1,8 @@
 export default function ArchivesPage() {
-    return (
-      <main>
-        <h1>Archives</h1>
-        <p>Hello World!</p>
-      </main>
-    );
-  }
-  
+  return (
+    <main className="archives-container">
+      <h1>Archives</h1>
+      <p>There are no current archives, please check back later!</p>
+    </main>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -47,7 +47,7 @@ main {
 
 /* NavBar */
 .navbar {
-  background-color: rgba(21, 73, 196, 0.6);
+  background-color: rgba(0, 0, 0, 0.6);
   padding: 16px;
  }
 
@@ -89,7 +89,7 @@ main {
 
 /* Footer */
 .footer {
-  background-color: rgba(21, 73, 196, 0.6);
+  background-color: rgb(0, 0, 0, 0.6);
   padding: 16px;
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,6 +15,21 @@ html, body {
   width: 100vw; 
 }
 
+html, body, #__next {
+  height: 100%;
+}
+
+body, #__next {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+main {
+  flex: 1;
+  padding: 20px auto;
+}
+
 /* Header */
 .header {
   display: flex;
@@ -49,6 +64,27 @@ html, body {
 .navbar ul li a {
   color: white;
   text-decoration: none;
+}
+
+/* Archives */
+
+.archives-container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.archives-container h1 {
+  text-align: center;
+  font-size: 2rem;
+  margin-bottom: 20px;
+}
+
+.archives-container p {
+  margin-top: 10px;
+  margin-bottom: 10px;
+  font-size: 0.9rem;
+  color: #666;
 }
 
 /* Footer */
@@ -638,4 +674,3 @@ max-width: 800px;
   font-size: 2rem;
   margin-bottom: 20px; 
 }
-


### PR DESCRIPTION
<!-- Please use the following format for the title:-->
<!-- <repo>_<sprint#>_<issue#>_<PR-title> -->

<!-- Example: appdev-repo_88_888_example-pr-name -->

<!-- Please fill out the following: -->
## Summary & Changes 📃
- **Resolves:** `#issue-108`

- **Summary:** (Briefly describe what this PR does)
  - 🔨 What does this issue fix?
  - This PR changes the color of the navbar and the footer so that it matches the requested color of black with a bit of transparency. 
  - 👀 What is the expected behavior?
  - When the user visit the site they are met with a navbar and footer of the color black.
  - 🗨️ Any relevant technical details?
  - N/A

- **Changes:**
  - ✅ List key changes made
  - Changed color of navbar and footer
  - 🛠️ Mention breaking changes (if any)
  - N/A
  - 🔗 Link relevant discussions/issues
  - Issue: https://github.com/SeattleColleges/licton-springs-review-nextjs/issues/109 
  - 📝 Additional info to assist developers & reviewers
  - All the changes occurred in the global.css file


## Screenshots / Visual Aids 🔎
![Screenshot_20250608_155745](https://github.com/user-attachments/assets/1a1e0dc3-ce45-4328-97da-60c770dc55da)
![Screenshot_20250608_155754](https://github.com/user-attachments/assets/d490dfe1-771c-4693-8946-eb82a5028990)


## How to Test 🧪
1. **Steps to Reproduce:**
   - Step 1: Clone branch to local environment
   - Step 2: Run npm run dev and navigate to localhost:3000
   - Step 3: Check out the navbar and footer
2. **Expected Behavior:** (Describe what should happen)
   - The page should load with a black navbar and footer  
4. **Actual Behavior (if bug):** (Describe what happens instead)


## Checklist ✅

- [ ] I have **tested** this PR **locally** and it works as expected.
- [ ] This PR **resolves an issue** (`Resolves #issue-number`).
- [ ] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [ ] **Squash commits** and enable **auto-merge** if approved.

