### PR TITLE
Added a link component to the header image

### DIFF
--- a/src/component/Header.tsx
+++ b/src/component/Header.tsx
@@ -1,5 +1,6 @@
 'use client';
 import Image from "next/image";
+import Link from "next/link";
 import { useState, useEffect } from "react";
 import SocialMediaLinks from './SocialMediaLinks';
 import SchoolLogo from './SchoolLogo'; 
@@ -29,7 +30,7 @@ export default function Header() {
             <div className="nsc-logo-container">
                 <SchoolLogo />
             </div>
-
+            <Link href="/">
             <Image
                 src="https://lictonspringsreview.com/wp-content/uploads/2024/02/cropped-LSRLogo_wideweb.png"
                 alt="Licton Springs Review Logo"
@@ -37,7 +38,7 @@ export default function Header() {
                 height="90"
                 className="header-logo"
             />
-
+            </Link>
             <p className="slogan">
                 Visual and literary art from the students, and alumni of North Seattle College
             </p>


### PR DESCRIPTION

licton-springs-review-nextjs_Sprint#24_issue#111_added-home-link-to-header

## Summary & Changes 📃
- **Resolves:** `#111r`

- **Summary:** (Briefly describe what this PR does)
This issue adds a link to the header so that when clicked people are taking back to the home page
- **Changes:**
  - Added Link component to the Header



## How to Test 🧪
1. **Steps to Reproduce:**
   - Step 1: Checkout my branch
   - Step 2: Run on local environment, via npm run dev, and then after clicking other tabs click on header to return to the homepage
2. **Expected Behavior:** (Describe what should happen)
   - Users should be returned to homepage after clicking the Title



## Checklist ✅

- [ ] I have **tested** this PR **locally** and it works as expected.
- [ ] This PR **resolves an issue** (`Resolves #issue-number`).
- [ ] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [ ] **Squash commits** and enable **auto-merge** if approved.

