### PR TITLE
licton-springs-review-nextjs_24_help-page-footer-bottom

### DIFF
--- a/src/app/help/page.tsx
+++ b/src/app/help/page.tsx
@@ -6,8 +6,8 @@ export default function Help() {
       <h1 style={{ textAlign: "center", marginBottom: "24px" }}>Help</h1>
 
       <p>
-        Welcome to the Licton Springs Review Help Center. Whether you're here to
-        submit your work, join our team, or explore past publications, we’re
+        Welcome to the Licton Springs Review Help Center. Whether you&apos;re here to
+        submit your work, join our team, or explore past publications, we&apos;re
         here to guide you every step of the way.
       </p>
 

--- a/src/app/help/page.tsx
+++ b/src/app/help/page.tsx
@@ -1,8 +1,52 @@
+import Link from "next/link";
+
 export default function Help() {
-    return (
-        <>
-            <h1>Help/Search</h1>
-            <p>Hello world!</p>
-        </>
-    );
+  return (
+    <div style={{ maxWidth: "800px", margin: "0 auto", padding: "20px" }}>
+      <h1 style={{ textAlign: "center", marginBottom: "24px" }}>Help</h1>
+
+      <p>
+        Welcome to the Licton Springs Review Help Center. Whether you're here to
+        submit your work, join our team, or explore past publications, we’re
+        here to guide you every step of the way.
+      </p>
+
+      <h2 style={{ marginTop: "32px", marginBottom: "16px" }}>
+         Frequently Asked Questions
+      </h2>
+
+      <p style={{ marginBottom: "16px" }}>
+        <strong>Q: Who can submit to the Licton Springs Review?</strong>
+        <br />
+        A: Submissions are open to all current North Seattle College students.
+        We welcome poetry, fiction, nonfiction, visual art, and multimedia
+        pieces.
+      </p>
+
+      <p style={{ marginBottom: "16px" }}>
+        <strong>Q: How do I submit my work?</strong>
+        <br />
+        A: Visit our <Link href="/submit">Submissions Page</Link> for
+        detailed guidelines and deadlines. Please ensure your files follow the
+        accepted formats.
+      </p>
+
+      <p style={{ marginBottom: "16px" }}>
+        <strong>Q: When will I hear back about my submission?</strong>
+        <br />
+        A: Submissions are reviewed after the posted deadline. You’ll be
+        notified of your submission status via email within 3–4 weeks.
+      </p>
+
+      <p style={{ marginBottom: "16px" }}>
+        <strong>
+          Q: Are there any current editorial or volunteer positions available?
+        </strong>
+        <br />
+        A: Editor and volunteer positions open throughout the academic year.
+        These roles are open to current NSC students. Check our{" "}
+        <Link href="/job">Jobs page</Link> for the latest updates.
+      </p>
+    </div>
+  );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,11 +36,12 @@ export default function RootLayout({
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        style={{ display: "flex", flexDirection: "column", minHeight: "100vh" }}
       >
         <Header/>
         <Navbar/>
       
-        <main>{children}</main>
+        <main style={{ flex: 1 }}>{children}</main>
         <Footer/>
       </body>
     </html>


### PR DESCRIPTION
## Summary & Changes 📃
- **Resolves:** #97 

- **Summary:** (Briefly describe what this PR does)
  - 🔨 What does this issue fix?
   Updates the Help page with official content, replaces placeholder text, improves FAQ formatting, and ensures the footer always sits at the bottom of the page.
  - 👀 What is the expected behavior?
   Users see updated, centered Help content with proper vertical spacing, and the footer stays anchored to the bottom regardless of content height.
  - 🗨️ Any relevant technical details?
   Utilizes flexbox on the body/main layout for footer positioning; Help page uses semantic headings and internal links for navigation.

- **Changes:**
  - Replaced Help page placeholder with Help Center intro and FAQ (with vertical spacing between questions).
  - Centered Help page title to match other main pages
  - Applied layout update using flexbox so the footer is always at the bottom.


## Screenshots / Visual Aids 🔎


https://github.com/user-attachments/assets/8de16c11-5a89-41c4-b067-a5751b5252eb



## How to Test 🧪
1. **Steps to Reproduce:**
   - Step 1: Go to the /help
   - Step 2: View the Help page and compare with the changes
2. **Expected Behavior:** (Describe what should happen)
   - Help page displays updated intro, FAQ section, and improved spacing.
   - The Help heading is centered.
   - Footer sits flush at the bottom of the browser window, regardless of content length.
4. **Actual Behavior (if bug):** (Describe what happens instead)
   - (Before) Help showed only placeholder; footer floated mid-screen on short pages.

## Checklist ✅

- [X] I have **tested** this PR **locally** and it works as expected.
- [X] This PR **resolves an issue** (`Resolves #issue-number`).
- [X] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [ ] **Squash commits** and enable **auto-merge** if approved.

