### PR TITLE
licton-springs-review-nextjs_19_Issue122-rename-nonfiction-to-essay

### DIFF
--- a/src/app/non-fiction/page.tsx
+++ b/src/app/non-fiction/page.tsx
@@ -47,7 +47,7 @@ export default async function NonFictionPage() {
 
     return (
         <main className="non-fiction-container">
-            <h1>Non-Fiction</h1>
+            <h1>Essay</h1>
             {/*2025 submissions*/}
             {articles}
             {/*Previous posts on WordPress*/}

--- a/src/component/Navbar.tsx
+++ b/src/component/Navbar.tsx
@@ -16,7 +16,7 @@ export default function Navbar() {
           <Link href="/fiction">Fiction</Link>
         </li>
         <li>
-          <Link href="/non-fiction">Non-Fiction</Link>
+          <Link href="/non-fiction">Essay</Link>
         </li>
         <li>
           <Link href="/submit">Submit</Link>

--- a/src/component/SingleNonfictionPost.tsx
+++ b/src/component/SingleNonfictionPost.tsx
@@ -136,7 +136,7 @@ export default function SingleNonfictionPost() {
             <article className={styles.detailContainer}>
                 <h1 className={styles.fictionTitle}>“{post.title}” by {post.author}</h1>
                 {i === 0 ? <p><strong>Marcia Barton Award Winner!</strong></p> : <></>}
-                <p>Published in <Link href="../../non-fiction">Non-Fiction</Link></p>
+                <p>Published in <Link href="../../non-fiction">Essay</Link></p>
                 <p className={styles.postDate}>Posted on 2025-06-10</p>
                 <div className={styles.contentContainer}>
                     {paragraphs}


### PR DESCRIPTION
**Resolves:** Issue #122

**Description:**
- [x] Changed page title from "Non-Fiction" to "Essay"
- [x] Updated navigation bar link/text from "Non-Fiction" to "Essay"
- [x] Verified that routing and links still work after renaming

**How to Test:**
1. Pull the latest changes
2. Run npm run dev
3. Check the main navigation bar, “Non-Fiction” should now be “Essay”
4. Navigate to the former Non-Fiction page, it should load correctly as the “Essay” page

**Expected Result:**
- [x] "Essay" correctly replaces "Non-Fiction" in the page and navbar
- [x] Layout and spacing remain clean and consistent
- [x] Font loads quickly without blocking page rendering

**Screenshot of Results:**

![NavBar](https://github.com/user-attachments/assets/57e6928f-9781-4eeb-b72d-d616e99c3339)

![EssayPage](https://github.com/user-attachments/assets/b13da7f7-52c4-47b1-99e2-15e8b96b0d74)

